### PR TITLE
changed night sky so it rotates with moon

### DIFF
--- a/shaders/dimensions/composite1.fsh
+++ b/shaders/dimensions/composite1.fsh
@@ -940,7 +940,17 @@ void main() {
 
 			
 			#if RESOURCEPACK_SKY == 1 || RESOURCEPACK_SKY == 0
-				vec3 orbitstar = vec3(feetPlayerPos_normalized.x,abs(feetPlayerPos_normalized.y),feetPlayerPos_normalized.z); orbitstar.x -= WsunVec.x*0.2;
+				vec3 orbitstar = vec3(feetPlayerPos_normalized.x,abs(feetPlayerPos_normalized.y),feetPlayerPos_normalized.z);
+
+				vec3 axis = vec3(0, sin(sunPathRotation*0.0174533), cos(sunPathRotation*0.0174533));
+				float s = -sqrt(1 - (WsunVec.x * WsunVec.x));
+				float c = WsunVec.x;
+				float oc = 1.0 - c;
+				
+				orbitstar *= mat3(c           , - axis.z * s            ,  axis.y * s,
+								  axis.z * s  , oc * axis.y * axis.y + c, oc * axis.y * axis.z,
+								  - axis.y * s, oc * axis.y * axis.z    , oc * axis.z * axis.z + c);
+				
 				Background += stars(orbitstar) * 10.0;
 			#endif
 

--- a/shaders/lib/stars.glsl
+++ b/shaders/lib/stars.glsl
@@ -41,7 +41,11 @@ float StableStarField( in vec2 vSamplePos, float fThreshhold )
 
 float stars(vec3 viewPos){
 
-	vec2 uv = abs(viewPos.x) > abs(viewPos.y) && abs(viewPos.x) > abs(viewPos.z) ? viewPos.yz : abs(viewPos.y) > abs(viewPos.z) ? viewPos.xz : viewPos.xy;
+	//6 "faces" in 3 axis
+	vec2 uv = abs(viewPos.x) > abs(viewPos.y) && abs(viewPos.x) > abs(viewPos.z) ? viewPos.yz : abs(viewPos.y) > abs(viewPos.z) ? viewPos.xz + vec2(1,0) : viewPos.xy + vec2(0,1);
+	//together with offsets make sure that every face is unique
+	uv = viewPos.x > 0 ? uv : uv + vec2(1,1);
+	//scale it down to stars are not too small and too dense
 	uv *= 0.5;
 
 	return exp((1.0-StableStarField(uv*1000.,0.999))  * -10) * 3;

--- a/shaders/lib/stars.glsl
+++ b/shaders/lib/stars.glsl
@@ -41,8 +41,8 @@ float StableStarField( in vec2 vSamplePos, float fThreshhold )
 
 float stars(vec3 viewPos){
 
-	float elevation = clamp(viewPos.y,0.,1.);
-	vec2 uv = viewPos.xz/(1.5+elevation);
+	vec2 uv = abs(viewPos.x) > abs(viewPos.y) && abs(viewPos.x) > abs(viewPos.z) ? viewPos.yz : abs(viewPos.y) > abs(viewPos.z) ? viewPos.xz : viewPos.xy;
+	uv *= 0.5;
 
 	return exp((1.0-StableStarField(uv*1000.,0.999))  * -10) * 3;
 	// return StableStarField(uv*1000.,0.999)*0.5*0.3;


### PR DESCRIPTION
"I am completely and mentally stable... oh hey I think I can fix those stars."

Stars now have proper rotation matrix, and are placed a bit like typical skybox with sort of 6 sides.
As a consequence of changing skybox star density increased A LOT so I scaled it back down to sort of match irl 5000 stars visible under perfect conditions... feel free to scale it down more.