### PR TITLE
don't write garbage data into colortex2 in all_solid.fsh

### DIFF
--- a/shaders/dimensions/all_solid.fsh
+++ b/shaders/dimensions/all_solid.fsh
@@ -446,13 +446,12 @@ void main() {
 	#ifdef HAND
 		if (Albedo.a > 0.1){
 			Albedo.a = 0.75;
-			gl_FragData[3] = vec4(0.0);
 		} else {
 			Albedo.a = 1.0;
 		}
 	#endif
 
-	#if defined PARTICLE_RENDERING_FIX && (defined ENTITIES || defined BLOCKENTITIES)
+	#if defined HAND || defined ENTITIES || defined BLOCKENTITIES
 		gl_FragData[3] = vec4(0.0);
 	#endif
 

--- a/shaders/dimensions/all_solid.fsh
+++ b/shaders/dimensions/all_solid.fsh
@@ -446,14 +446,14 @@ void main() {
 	#ifdef HAND
 		if (Albedo.a > 0.1){
 			Albedo.a = 0.75;
-			gl_FragData[3].a = 0.0;
+			gl_FragData[3] = vec4(0.0);
 		} else {
 			Albedo.a = 1.0;
 		}
 	#endif
 
 	#if defined PARTICLE_RENDERING_FIX && (defined ENTITIES || defined BLOCKENTITIES)
-		gl_FragData[3].a = 0.0;
+		gl_FragData[3] = vec4(0.0);
 	#endif
 
 	


### PR DESCRIPTION
This fixes discoloured entities and block entities behind translucents. it also appears to fix the enchantment glint, but I am not sure why.