### PR TITLE
Revert FloodFill Shadow Hack

### DIFF
--- a/shaders/lib/settings.glsl
+++ b/shaders/lib/settings.glsl
@@ -718,7 +718,7 @@ const vec3 aerochrome_color = mix(vec3(1.0, 0.0, 0.0), vec3(0.715, 0.303, 0.631)
 //#define LPV_COLORED_CANDLES
 
 // Fix for making nether/end work until next Iris release to fix shadow matrices
-//#define LPV_NOSHADOW_HACK
+#define LPV_NOSHADOW_HACK
 
 #ifdef LPV_ENABLED
 	#ifdef IRIS_FEATURE_CUSTOM_IMAGES


### PR DESCRIPTION
Re-enable Iris shadow hack for floodfill, fix is not released yet. I forgot I was using a special release from IMS with the upcoming fix.