### PR TITLE
add support for Iris BLOCK_EMISSION_ATTRIBUTE to auto add lights to floodfill

### DIFF
--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -8,7 +8,7 @@ separateAo = true
 rain.depth = false
 beacon.beam.depth = true
 
-iris.features.optional = ENTITY_TRANSLUCENT REVERSED_CULLING COMPUTE_SHADERS CUSTOM_IMAGES
+iris.features.optional = ENTITY_TRANSLUCENT REVERSED_CULLING COMPUTE_SHADERS CUSTOM_IMAGES BLOCK_EMISSION_ATTRIBUTE
 
 #if RESOURCEPACK_SKY == 2
     sun=true

--- a/shaders/world-1/shadow.vsh
+++ b/shaders/world-1/shadow.vsh
@@ -16,7 +16,11 @@ Read the terms of modification and sharing before changing something below pleas
 
 #ifdef IS_LPV_ENABLED
 	attribute vec4 mc_Entity;
-	attribute vec3 at_midBlock;
+	#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+		attribute vec4 at_midBlock;
+	#else
+		attribute vec3 at_midBlock;
+	#endif
 	attribute vec3 vaPosition;
 
 	uniform mat4 shadowModelViewInverse;
@@ -48,9 +52,12 @@ void main() {
 			renderStage == MC_RENDER_STAGE_TERRAIN_SOLID || renderStage == MC_RENDER_STAGE_TERRAIN_TRANSLUCENT ||
 			renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT || renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED
 		) {
-			vec3 originPos = playerpos + at_midBlock/64.0;
+			vec3 originPos = playerpos + at_midBlock.xyz/64.0;
 
 			uint voxelId = uint(mc_Entity.x + 0.5);
+			#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+				if (voxelId == 0u && at_midBlock.w > 0) voxelId = BLOCK_LIGHT_1 + uint(at_midBlock.w - 1);
+			#endif
 			if (voxelId == 0u) voxelId = 1u;
 
 			SetVoxelBlock(originPos, voxelId);

--- a/shaders/world0/shadow.vsh
+++ b/shaders/world0/shadow.vsh
@@ -54,7 +54,11 @@ uniform int entityId;
 #include "/lib/entities.glsl"
 
 #ifdef IS_LPV_ENABLED
-	attribute vec3 at_midBlock;
+	#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+		attribute vec4 at_midBlock;
+	#else
+		attribute vec3 at_midBlock;
+	#endif
     uniform int currentRenderedItemId;
 	uniform int renderStage;
 
@@ -204,9 +208,12 @@ void main() {
 			renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT || renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED
 		) {
 			uint voxelId = uint(blockId);
+			#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+				if (voxelId == 0u && at_midBlock.w > 0) voxelId = BLOCK_LIGHT_1 + uint(at_midBlock.w - 1);
+			#endif
 			if (voxelId == 0u) voxelId = 1u;
 
-			vec3 originPos = playerpos + at_midBlock/64.0;
+			vec3 originPos = playerpos + at_midBlock.xyz/64.0;
 
 			SetVoxelBlock(originPos, voxelId);
 		}

--- a/shaders/world1/shadow.vsh
+++ b/shaders/world1/shadow.vsh
@@ -16,7 +16,11 @@ Read the terms of modification and sharing before changing something below pleas
 
 #ifdef IS_LPV_ENABLED
 	attribute vec4 mc_Entity;
-	attribute vec3 at_midBlock;
+	#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+		attribute vec4 at_midBlock;
+	#else
+		attribute vec3 at_midBlock;
+	#endif
 	attribute vec3 vaPosition;
 
 	uniform mat4 shadowModelViewInverse;
@@ -48,9 +52,12 @@ void main() {
 			renderStage == MC_RENDER_STAGE_TERRAIN_SOLID || renderStage == MC_RENDER_STAGE_TERRAIN_TRANSLUCENT ||
 			renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT || renderStage == MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED
 		) {
-			vec3 originPos = playerpos + at_midBlock/64.0;
+			vec3 originPos = playerpos + at_midBlock.xyz/64.0;
 
 			uint voxelId = uint(mc_Entity.x + 0.5);
+			#ifdef IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE
+				if (voxelId == 0u && at_midBlock.w > 0) voxelId = BLOCK_LIGHT_1 + uint(at_midBlock.w - 1);
+			#endif
 			if (voxelId == 0u) voxelId = 1u;
 
 			SetVoxelBlock(originPos, voxelId);


### PR DESCRIPTION
this assigns unmapped blocks the light block id of the light level provided by iris

could be separated if they should have a differnet color