### PR TITLE
FloodFill Offset Check

### DIFF
--- a/shaders/dimensions/all_translucent.fsh
+++ b/shaders/dimensions/all_translucent.fsh
@@ -722,7 +722,10 @@ if (gl_FragCoord.x * texelSize.x < 1.0  && gl_FragCoord.y * texelSize.y < 1.0 )	
 	#endif
 
 	#ifdef IS_LPV_ENABLED
-		vec3 normalOffset = 0.5*worldSpaceNormal;
+		vec3 normalOffset = vec3(0.0);
+
+		if (any(greaterThan(abs(worldSpaceNormal), vec3(1.0e-6))))
+			normalOffset = 0.5*worldSpaceNormal;
 
 		#if LPV_NORMAL_STRENGTH > 0
 			if (any(greaterThan(abs(normal), vec3(1.0e-6)))) {

--- a/shaders/dimensions/composite1.fsh
+++ b/shaders/dimensions/composite1.fsh
@@ -1057,7 +1057,10 @@ void main() {
 		#endif
 	
 		#ifdef IS_LPV_ENABLED
-			vec3 normalOffset = 0.5*viewToWorld(FlatNormals);
+			vec3 normalOffset = vec3(0.0);
+
+			if (any(greaterThan(abs(FlatNormals), vec3(1.0e-6))))
+				normalOffset = 0.5*viewToWorld(FlatNormals);
 
 			#if LPV_NORMAL_STRENGTH > 0
 				vec3 texNormalOffset = -normalOffset + slopednormal;


### PR DESCRIPTION
This might not actually fix anything, but it prevents doing any offset from the geometry-normal if it's zero/NaN. If it _does_ work than hopefully no more glowing nametags from floodfill. On my end there was no issue to begin with, so I assume it's mod related.