### PR TITLE
Fix RP sky killing translucent rendering and add guards

### DIFF
--- a/shaders/dimensions/deferred2.fsh
+++ b/shaders/dimensions/deferred2.fsh
@@ -4,6 +4,7 @@ uniform sampler2D depthtex0;
 uniform sampler2D dhDepthTex;
 uniform sampler2D colortex1;
 uniform sampler2D colortex2;
+uniform sampler2D colortex7;
 uniform vec2 texelSize;
 
 
@@ -27,29 +28,33 @@ float interleaved_gradientNoise(){
 
 void main() {
 
-	vec2 texcoord = gl_FragCoord.xy * texelSize;
+	ivec2 pixelCoord = ivec2(gl_FragCoord.xy);
+	float depth = texelFetch2D(depthtex0, pixelCoord, 0).x;
+	gl_FragData[0] = texelFetch2D(colortex1, pixelCoord, 0);
 
-	gl_FragData[0] = texelFetch2D(colortex1, ivec2(gl_FragCoord.xy),0);
+	bool isSkyPixel = depth >= 1.0;
+	#ifdef DISTANT_HORIZONS
+		float dhDepth = texelFetch2D(dhDepthTex, pixelCoord, 0).x;
+		isSkyPixel = isSkyPixel && dhDepth >= 1.0;
+	#endif
 
-	if(
-		texelFetch2D(depthtex0, ivec2(gl_FragCoord.xy), 0).x < 1.0 
-		
-		#ifdef DISTANT_HORIZONS
-			|| texelFetch2D(dhDepthTex, ivec2(gl_FragCoord.xy), 0).x < 1.0
-		#endif
+#if RESOURCEPACK_SKY != 0
+	vec4 forwardSample = texelFetch2D(colortex2, pixelCoord, 0);
+	float translucentMask = texelFetch2D(colortex7, pixelCoord, 0).a;
 
-	) {
-		// doing this for precision reasons, DH does NOT like depth => 1.0
-	}else{
-		
-		vec3 skyColor = texelFetch2D(colortex2, ivec2(gl_FragCoord.xy),0).rgb;
+	if(isSkyPixel){
+		vec3 skyColor = forwardSample.rgb;
 		skyColor.rgb = max(skyColor.rgb - skyColor.rgb * interleaved_gradientNoise()*0.05, 0.0);
 
 		gl_FragData[0].rgb = skyColor/50.0;
 		gl_FragData[0].a = 0.0;
-
 	}
+#endif
 
-	gl_FragData[1] = vec4(0,0,0,0);
+#if RESOURCEPACK_SKY != 0
+	gl_FragData[1] = isSkyPixel ? vec4(0.0) : (translucentMask > 0.0 ? forwardSample : vec4(0.0));
+#else
+	gl_FragData[1] = vec4(0.0);
+#endif
 
 }


### PR DESCRIPTION
rerouted rp sky rendering to a dedicated buffer so the forward translucency buffer stays empty, then had the deferred pass read that new attachment instead. This keeps the rp sky/sun visible without erasing translucent players or overlays

also added some guards for rp sky checks

**Before:**
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/4da33e74-b6f2-4b83-b247-663ff0c49b8f" />

**After:**
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/e6c0d228-a692-4c9d-9238-4a336a51d81b" />
---
![goku](https://github.com/user-attachments/assets/8cb98246-abd4-48b8-b4f3-f4b6e8baa1f3)
