### PR TITLE
Improved built-in emission by multiplying by albedo brightness

### DIFF
--- a/shaders/dimensions/all_solid.fsh
+++ b/shaders/dimensions/all_solid.fsh
@@ -626,12 +626,12 @@ void main() {
 		#endif
 
 		#if EMISSIVE_TYPE == 1
-			gl_FragData[1].a = EMISSIVE;
+			gl_FragData[1].a = EMISSIVE * sqrt(RgbToHsv(Albedo.rgb)[2]);
 		#endif
 
 		#if EMISSIVE_TYPE == 2
 			gl_FragData[1].a = SpecularTex.a;
-			if(SpecularTex.a <= 0.0) gl_FragData[1].a = EMISSIVE;
+			if(SpecularTex.a <= 0.0) gl_FragData[1].a = EMISSIVE * sqrt(RgbToHsv(Albedo.rgb)[2]);
 		#endif
 
 		#if EMISSIVE_TYPE == 3		


### PR DESCRIPTION
Not as advanced as the built-in emission improvements made in Eclipse, but a small change improving the built-in emission quite a bit, at least in my opinion.  
It results with a bit more contrast, and only bright pixels being emissive make sense.  
I also tried without `sqrt()` there is even more contrast, and I think I might even like it more that way, but some stuff can start to look quite weird...

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/3833b639-5e37-46a0-8fb3-e57ade1743f2" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/6c029866-0ae1-4c85-a934-4ce71ab182ed" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/77456202-4229-4a83-9f74-ec3a683a1a05" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/e8b97278-6476-4b5a-b995-63462ce94076" />

Off:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/441a7800-56e2-44aa-9b97-a2af6d6f8ebd" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/c951bec4-c8d0-4131-a428-d055a4c66363" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/458d7c7b-bc68-46b4-b1cf-e37eed1c3b33" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/9b56b971-60ca-44c8-a174-3ddcbf733523" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/f2d8030a-ffe6-4a5b-9cb3-128c7e5c2c77" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/6396f286-c1b4-44c2-9e01-e334d0cdd37e" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/8d546d55-0076-4180-bb35-7c957d77b99e" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/45cde1c6-75ed-49b0-8088-a2bc9d2057fc" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/cb2895a4-de89-4a82-81a2-7474079138c5" />

---

Current:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/3c5a4c3d-6160-4908-a580-9730282e3b95" />

Improved:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/e6758542-b920-49c8-a7a7-b7da561585f6" />

Eclipse:
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/1d6e9459-c6c0-4924-b7ac-fff025533a84" />
