### PR TITLE
Fix double glass shadows

### DIFF
--- a/shaders/world0/shadow.fsh
+++ b/shaders/world0/shadow.fsh
@@ -2,8 +2,10 @@
 #define DIRECT_LIGHT_RELATED_SETTINGS
 #define SHADOWMAP_CONSTANT_RELATED_SETTINGS
 #include "/lib/settings.glsl"
+#include "/lib/blocks.glsl"
 
 varying vec4 color;
+varying float shadowBlockId;
 
 varying vec2 texcoord;
 uniform sampler2D tex;
@@ -20,6 +22,7 @@ float blueNoise(){
 }
 
 void main() {
+	if (!gl_FrontFacing && shadowBlockId >= float(BLOCK_GLASS) && shadowBlockId <= float(BLOCK_GLASS_YELLOW)) discard;
 	
 	vec4 shadowColor = vec4(texture(tex,texcoord.xy).rgb * color.rgb,  texture2DLod(tex, texcoord.xy, 0).a);
 

--- a/shaders/world0/shadow.vsh
+++ b/shaders/world0/shadow.vsh
@@ -47,6 +47,7 @@ uniform vec3 shadowLightVec;
 uniform float shadowMaxProj;
 attribute vec4 mc_midTexCoord;
 varying vec4 color;
+varying float shadowBlockId;
 
 attribute vec4 mc_Entity;
 uniform int blockEntityId;
@@ -204,6 +205,7 @@ void main() {
 	// #endif
 
 	int blockId = int(mc_Entity.x + 0.5);
+	shadowBlockId = float(blockId);
 
 	vec3 worldpos = playerpos;
 	#if FOLIAGE_ANIMATION_AMOUNT > 0


### PR DESCRIPTION
discarded all glass backfaces in the shadow pass (): all blocks between 301 and 317 (from glass block to yellow glass block)
pulled block id from vertex to fragment in order to identify it by id.

here's before
<img width="1033" height="700" alt="Discord_Y13OHzeD2N" src="https://github.com/user-attachments/assets/8e0d1ce2-d623-4724-8d2e-3c6a0d64f366" />
<img width="607" height="477" alt="Discord_UZZQeIwNo7" src="https://github.com/user-attachments/assets/ecc288ba-06fa-407e-aad1-8e69ec1d572a" />
<img width="993" height="565" alt="Discord_vLnqikeKse" src="https://github.com/user-attachments/assets/dfca0310-e882-4ce7-b99c-de083f23d006" />

after
<img width="420" height="397" alt="Discord_WOpyZZyTFH" src="https://github.com/user-attachments/assets/6c72e147-998a-46e0-a984-174e2f0094ae" />
<img width="1185" height="769" alt="Discord_trKglE7i7i" src="https://github.com/user-attachments/assets/c8f31006-7795-43df-9c1b-5b5a758d2910" />
<img width="1322" height="823" alt="Discord_lHLzd5YsxE" src="https://github.com/user-attachments/assets/ce61f4ad-aee9-4565-8edd-211ecbf1dbb5" />


here's shadow map debug too
before
<img width="1592" height="868" alt="image" src="https://github.com/user-attachments/assets/88c92395-7305-4b37-bb27-45291eb10fb1" />

after
<img width="761" height="672" alt="image" src="https://github.com/user-attachments/assets/f158f05c-fd22-4fea-8025-2d6e462f3ec6" />



hope this doesnt break anything else :]